### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python deck_dealer.py"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ DOGE: D8eQgEX3B3TJYqFDgYQMj6RbfxvrhJEu5K
 
 Mahalo!
 deusopus@gmail.com
+
+[![Run on Repl.it](https://repl.it/badge/github/deusopus/grass-shack-games)](https://repl.it/github/deusopus/grass-shack-games)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).